### PR TITLE
Fix implicit masking for non-float datatypes.

### DIFF
--- a/config/snpm_bch_ui.m
+++ b/config/snpm_bch_ui.m
@@ -283,7 +283,9 @@ im.help    = {
               ''
               'For image data-types without a representation of NaN, zero is the mask value, and the user can choose whether zero voxels should be masked out or not.'
               ''
-              'By default, an implicit mask is used. '
+              'By default, an implicit mask is used.'
+              ''
+              'It is ill-advised to mix input images, but if data are a mix of integer (no NaN''s) and float/double datatypes, implicit masking will only occur with NaN''s.'
               ''
 }';
 im.labels = {

--- a/snpm_pp.m
+++ b/snpm_pp.m
@@ -1619,7 +1619,7 @@ elseif ~isempty(C)
     xlabel(sprintf('Max Cluster Size Observed = %g  Cluster Threshold = %g',C(1),cC))
   end
   Ylim = get(gca,'ylim'); Xlim = get(gca,'xlim');
-  set(gca,'Xticklabel',num2str(str2num(get(gca,'Xticklabel')).^3))
+  set(gca,'Xticklabel',num2str(str2double(cellstr(get(gca,'Xticklabel'))).^3))
   line(rC(1)*[1 1],Ylim.*[1 0.95],'LineStyle','--','color',[1 0 0]);
   text(rC(1)+diff(Xlim)*0.01,Ylim(2)*0.95,'Observed','FontSize',10)
   line(cC.^(1/3)*[1 1],Ylim.*[1 0.85],'LineStyle','-');

--- a/snpm_ui.m
+++ b/snpm_ui.m
@@ -479,6 +479,10 @@ elseif iGXcalc==3
   %-Compute global values
   rg     = zeros(nScan,1);
   for i  = 1:nScan, rg(i)=spm_global(V(i)); end
+  if any(~isfinite(rg))
+    disp(rg)
+    error('Global computation returned NaN! Cannot continue')
+  end
   GX     = rg;
 elseif iGXcalc==1
   rg     = [];

--- a/snpm_ui.m
+++ b/snpm_ui.m
@@ -122,7 +122,7 @@ function snpm_ui(varargin)
 % sDesign       Description of PlugIn design
 % V             Memory mapping handles
 % MASK          Filename of explicit mask image
-% ImMASKING     Implicit masking; 0=none; 1=zeros are equivalent to NaN
+% ImMASK        Implicit masking; 0=none; 1=zeros are equivalent to NaN
 % 
 % df            degrees of freedom due to error
 % sDesSave      String of PlugIn variables to save to cfg file
@@ -431,7 +431,7 @@ end
 
 %-Implicit Masking - Batch only!
 %-----------------------------------------------------------------------
-ImMASKING=job.masking.im;
+ImMASK=job.masking.im;
 
 %-Get analysis mask
 %-----------------------------------------------------------------------
@@ -577,7 +577,7 @@ CONT  = [CONT, zeros(size(CONT,1),size([B G],2))];
 %-----------------------------------------------------------------------
 s_SnPMcfg_save = ['s_SnPMcfg_save H C B G HCBGnames P PiCond ',...
 	'sPiCond bhPerms sHCform iGloNorm sGloNorm GM rg GX GMscale CONT ',...
-	'THRESH MASK TH bVarSm vFWHM sVarSm bVolm bST sDesFile sDesign ',...
+	'THRESH MASK ImMASK TH bVarSm vFWHM sVarSm bVolm bST sDesFile sDesign ',...
         'V pU_ST_Ut df1 ', ...
 	'sDesSave ',sDesSave];
 eval(['save SnPMcfg ',s_SnPMcfg_save])


### PR DESCRIPTION
Previously, implicit masking *was* given as an option, but in fact was not implemented for integer input data (i.e. data with no NaN representation).  Now it is properly implemented.

@cmaumet: Can you review my changes, and run any tests needed and then merge if you see fit?