### PR TITLE
fix: 'Error using ==. Matrix dimensions must agree'

### DIFF
--- a/snpm_STcalc.m
+++ b/snpm_STcalc.m
@@ -126,6 +126,14 @@ switch (lower(varargin{1}))
   end 
   
   [N,Z,M,A] = spm_max(ST,XYZ);
+  
+  % Enfore A to be a column vector. When XYZ locations are defined in a 1D 
+  % space, spm_max returns A as a row vector instead of a column which 
+  % makes find(A==i) fails later in the code below. 
+  if size(A,2) > 1
+      A = A';
+  end
+  
   Aindex = spm_clusters(XYZ); %- cluster indexes
     
   STCS = snpm_STcalc('initK',STCS,max(A),isPos,perm);


### PR DESCRIPTION
This pull request fixes an error identified by Rik Henson when running a paired t-test. The error was only raised for some of the permutations and produced the following error message:
```
Running 'Compute'

SnPM: snpm_cp
========================================================================
Initialising...
Working on correct permutation...
Working on the whole volume
	Perm    1:   0' 0" (  0% Sm)
[...]
	Perm   92:   0' 0" (  0% Sm)
	Perm   93:   0' 0" (  0% Sm)
	Perm   94:   0' 0" (  0% Sm)
	Perm   95:   0' 0" (  0% Sm)
	Perm   96:   0' 0" (  0% Sm)
	Perm   97:   0' 0" (  0% Sm)
	Perm   98:   0' 0" (  0% Sm)
	Perm   99:   0' 0" (  0% Sm)
Failed  'Compute'
Error using  == 
Matrix dimensions must agree.
In file ".../spm12/toolbox/SnPM13/snpm_STcalc.m" (???), function "snpm_STcalc" at line 145.
In file ".../spm12/toolbox/SnPM13/snpm_cp.m" (???), function "snpm_cp" at line 991.
In file ".../spm12/toolbox/SnPM13/config/snpm_run_cp.m" (???), function "snpm_run_cp" at line 13.
``` 

Tracking this down showed that when `XYZ` locations entered to `spm_max` are in a 1D space, the output `A` is a row vector (rather than a column vector). When `A` is a row vector, then [snpm_STcalc.m#L136](https://github.com/nicholst/SnPM-devel/blob/master/snpm_STcalc.m#L136), i.e.:
```
for i = unique(A)'
```
assigns a vector to `i` rather than each value of the vector `A` in turn.

The fix provided here ensures that `A` is always column vector.